### PR TITLE
Make sure module documentation snippets are valid

### DIFF
--- a/plugins/modules/alteon_config_health_check_tcp.py
+++ b/plugins/modules/alteon_config_health_check_tcp.py
@@ -179,7 +179,7 @@ options:
       connection_termination:
         description:
           - Set connection termination.
-          - Value for the tcphalfopen out-of-the-box health check: RST.
+          - "Value for the tcphalfopen out-of-the-box health check: RST."
         required: false
         default: fin
         choices:

--- a/plugins/modules/alteon_config_ssl_cert_group.py
+++ b/plugins/modules/alteon_config_ssl_cert_group.py
@@ -94,47 +94,46 @@ options:
       - Parameters for SSL certificate configuration.
     suboptions:
       index:
-      description:
-        - Certificate group ID.
-      required: true
-      default: null
-      type: str
+        description:
+          - Certificate group ID.
+        required: true
+        default: null
+        type: str
       certificate_type:
-      description:
-        - Certificate type.
-      required: false
-      default: null
-      choices:
-      - serverCertificate
-      - trustedCertificate
-      - intermediateCertificate
-      description:
-      description:
-        -  Certificate group description.
-      required: false
-      default: null
-      type: str
+        description:
+          - Certificate type.
+        required: false
+        default: null
+        choices:
+        - serverCertificate
+        - trustedCertificate
+        - intermediateCertificate
+        description:
+          -  Certificate group description.
+        required: false
+        default: null
+        type: str
       default_server_certificate:
-      description:
-        - Default server certificate, applicable to certificate_type=serverCertificate.
-      required: false
-      default: null
-      type: str
+        description:
+          - Default server certificate, applicable to certificate_type=serverCertificate.
+        required: false
+        default: null
+        type: str
       certificate_chaining_mode:
-      description:
-        - Certificate chaining mode.
-      required: false
-      default: null
-      choices:
-      - bySubjectIssuer
-      - bySkidAkid
-      certificate_names:
-      description:
-        - Certificate names belong to group.
-      required: false
-      default: null
-      type: list
-      elements: str
+        description:
+          - Certificate chaining mode.
+        required: false
+        default: null
+        choices:
+        - bySubjectIssuer
+        - bySkidAkid
+        certificate_names:
+        description:
+          - Certificate names belong to group.
+        required: false
+        default: null
+        type: list
+        elements: str
 notes:
   - Requires the Radware alteon-sdk Python package on the host. This is as easy as
       C(pip3 install alteon-sdk)

--- a/plugins/modules/alteon_config_system_logging.py
+++ b/plugins/modules/alteon_config_system_logging.py
@@ -121,7 +121,7 @@ options:
       session_log_state:
         description:
           - Enables or disables session log.
-          - Caution: Turning on the session log may impair Alteon traffic-processing performance.
+          - "Caution: Turning on the session log may impair Alteon traffic-processing performance."
         required: false
         default: disabled
         choices:

--- a/plugins/modules/alteon_config_system_management_access.py
+++ b/plugins/modules/alteon_config_system_management_access.py
@@ -73,7 +73,7 @@ options:
     required: true
     default: null
     choices:
-   - present
+    - present
     - absent
     - read
     - overwrite

--- a/plugins/modules/alteon_config_system_time_date.py
+++ b/plugins/modules/alteon_config_system_time_date.py
@@ -97,14 +97,14 @@ options:
       date_mm_dd_yyyy:
         description:
           - The date on the real-time clock, in M/D/YYYY format.
-          - Note: A zero-length string is displayed if the date is not available.
+          - "Note: A zero-length string is displayed if the date is not available."
         required: false
         default: null
         type: str
       time_hh_mm_ss:
         description:
           - The time on the real-time clock, in hh:mm:SS format.
-          - Note: A zero-length string is displayed if the time is not available.
+          - "Note: A zero-length string is displayed if the time is not available."
         required: false
         default: null
         type: str

--- a/plugins/modules/alteon_config_virtual_server.py
+++ b/plugins/modules/alteon_config_virtual_server.py
@@ -133,10 +133,10 @@ options:
         - disabled
       domain_name:
         description:
-          - Specifies the domain name for this virtual server. When configured the domain name is used for:
+          - "Specifies the domain name for this virtual server. When configured the domain name is used for:"
           - DNS resolution for global load balancing. Additional domains can be defined on the same virtual server by attaching multiple DNS (GSLB) rules, each with a different domain.
           - HTTP/S health check, if the health check Host parameter is set to Inherit.
-          -
+          - ""
           - The domain name typically includes the name of the company or organization, and the Internet group code (.com, .edu, .gov, .org, and so on). For example, 'foocorp.com'.
           - It does not include the hostname portion (www, www2, ftp, and so on).
         required: false

--- a/plugins/modules/alteon_config_virtual_service.py
+++ b/plugins/modules/alteon_config_virtual_service.py
@@ -282,7 +282,7 @@ options:
         description:
           - Specifies whether to enable or disable session logging.
           - Session logs are sent to the syslog servers via the data port when the sessions are deleted or aged out. The Alteon switch processor sends the buffered session logging data to the syslog server at regular intervals (every 30 seconds) if the buffer is not completely filled. There will be no session syslog if no sessions have aged out during this duration of 30 seconds.
-          - Note: Syslog servers configured on Alteon must be accessible via the data ports.
+          - "Note: Syslog servers configured on Alteon must be accessible via the data ports."
         required: false
         default: disabled
         choices:


### PR DESCRIPTION
Documentation for certain modules contained a few strings that YAML parser parsed as mapping since they contained an unquoted colon.

And while we were at it, we also fixed some indentation problems.