### PR TITLE
remove support in APM feature from ansible modules. 

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -20,5 +20,5 @@ tags:
 - collection
 - networking
 - sdn
-version: 0.0.19
+version: 0.1.01
 

--- a/plugins/modules/alteon_config_system_alerts.py
+++ b/plugins/modules/alteon_config_system_alerts.py
@@ -118,7 +118,7 @@ options:
         required: false
         default: null
         type: int
-      apm_pgpm_threshold_percent:
+      apm_pgpm_threshold_percent: obsolete
         description:
           - The threshold, in percent, of the license capacity APM PgPM (page per minute) for sending an alert.
         required: false


### PR DESCRIPTION
 also fixed DE68259. remove APM support in Alteon cuased alteon_config_system_alerts module to stop working. since agNewCfgThresholdApm returned error