### PR TITLE
ansible modules | AL-22087 | Ansible Alteon deployment on VMware with vapp_properties can't config mgmt ip

### DIFF
--- a/examples/vapp-properties/README.md
+++ b/examples/vapp-properties/README.md
@@ -1,3 +1,12 @@
 
 # vapp-properties example
 Example for Alteon spin up using vApp properties and Ansible automation.
+In order for this example to use the vApp option successfully, the following conditions must apply:
+1.	Before converting a machine to template, you must enable the vApp options:
+    a.	Go to configure->settings->vApp options.
+    b.	Click on EDIT
+    c.  Go to OVF details.
+    d.	Mark the options “iso image” and “VMware tools”.
+    e.	Click ok.
+2.	The machine that you are converting to template must not have any configuration. Therefore do not turn on the machine before you convert it to template.
+

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -21,5 +21,5 @@ tags:
 - collection
 - networking
 - sdn
-version: 0.6.1
+version: 0.6.2
 


### PR DESCRIPTION
In order for this example to use the vApp option successfully, the following conditions must apply:
1.	Before converting a machine to template, you must enable the vApp options:
a.	Go to configure->settings->vApp options.
b.	Click on Edit->OVF details.
c.	Mark the options “iso image” and “VMware tools”.
d.	Click ok.
2.	The machine that you are converting to template must not have any configuration. Therefore do not turn on the machine before you convert it to template.
